### PR TITLE
[Feat] 승진 계획 관리 기능 구현 및 후보자 자동 선정 로직 추가

### DIFF
--- a/hero-be/src/main/java/com/c4/hero/common/exception/ErrorCode.java
+++ b/hero-be/src/main/java/com/c4/hero/common/exception/ErrorCode.java
@@ -181,7 +181,18 @@ public enum ErrorCode {
     /**
      * 급여 계산에 필요한 근태 로그 자체가 존재하지 않는 경우
      */
-    PAYROLL_ATTENDANCE_LOG_NOT_FOUND(HttpStatus.BAD_REQUEST, "P107", "근태 로그가 없어 급여 계산이 불가합니다.");
+    PAYROLL_ATTENDANCE_LOG_NOT_FOUND(HttpStatus.BAD_REQUEST, "P107", "근태 로그가 없어 급여 계산이 불가합니다."),
+
+    // ===== 승진(Promotion) 관련 에러 =====
+    /**
+     * 승진 계획을 찾을 수 없음
+     */
+    PROMOTION_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PR001", "해당 승진 계획을 찾을 수 없습니다."),
+
+    /**
+     * 올바르지 않은 승진 대상 직급
+     */
+    INVALID_PROMOTION_TARGET_GRADE(HttpStatus.BAD_REQUEST, "PR002", "올바르지 않은 승진 대상 직급입니다.");
 
     /** HTTP 상태 코드 */
     private final HttpStatus status;

--- a/hero-be/src/main/java/com/c4/hero/common/exception/GlobalExceptionHandler.java
+++ b/hero-be/src/main/java/com/c4/hero/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.c4.hero.common.exception;
 
-import com.c4.hero.common.response.ApiResponse;
+import com.c4.hero.common.response.CustomResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -38,12 +38,12 @@ public class GlobalExceptionHandler {
      * @return 에러 응답 (ErrorCode에 정의된 상태 코드)
      */
     @ExceptionHandler(BusinessException.class)
-    protected ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+    protected ResponseEntity<CustomResponse<Void>> handleBusinessException(BusinessException e) {
         log.error("BusinessException: {}", e.getMessage(), e);
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getStatus())
-                .body(ApiResponse.error(errorCode.getCode(), e.getMessage()));
+                .body(CustomResponse.error(errorCode.getCode(), e.getMessage()));
     }
 
     /**
@@ -56,13 +56,13 @@ public class GlobalExceptionHandler {
      * @return 400 Bad Request와 유효성 검증 실패 메시지
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    protected ResponseEntity<CustomResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException: {}", e.getMessage());
         // 첫 번째 유효성 검증 실패 메시지 반환
         String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         return ResponseEntity
                 .badRequest()
-                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE.getCode(), message));
+                .body(CustomResponse.error(ErrorCode.INVALID_INPUT_VALUE.getCode(), message));
     }
 
     /**
@@ -75,12 +75,12 @@ public class GlobalExceptionHandler {
      * @return 400 Bad Request와 바인딩 실패 메시지
      */
     @ExceptionHandler(BindException.class)
-    protected ResponseEntity<ApiResponse<Void>> handleBindException(BindException e) {
+    protected ResponseEntity<CustomResponse<Void>> handleBindException(BindException e) {
         log.error("BindException: {}", e.getMessage());
         String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         return ResponseEntity
                 .badRequest()
-                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE.getCode(), message));
+                .body(CustomResponse.error(ErrorCode.INVALID_INPUT_VALUE.getCode(), message));
     }
 
     /**
@@ -94,11 +94,11 @@ public class GlobalExceptionHandler {
      * @return 500 Internal Server Error와 서버 오류 메시지
      */
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+    protected ResponseEntity<CustomResponse<Void>> handleException(Exception e) {
         log.error("Exception: {}", e.getMessage(), e);
         return ResponseEntity
                 .internalServerError()
-                .body(ApiResponse.error(
+                .body(CustomResponse.error(
                         ErrorCode.INTERNAL_SERVER_ERROR.getCode(),
                         ErrorCode.INTERNAL_SERVER_ERROR.getMessage()
                 ));

--- a/hero-be/src/main/java/com/c4/hero/common/response/CustomResponse.java
+++ b/hero-be/src/main/java/com/c4/hero/common/response/CustomResponse.java
@@ -26,7 +26,7 @@ import lombok.Getter;
  */
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL) // null 값은 JSON에 포함하지 않음
-public class ApiResponse<T> {
+public class CustomResponse<T> {
 
     /** 성공 여부 (true: 성공, false: 실패) */
     private final boolean success;
@@ -44,7 +44,7 @@ public class ApiResponse<T> {
      * private 생성자
      * 정적 팩토리 메서드를 통해서만 생성 가능
      */
-    private ApiResponse(boolean success, T data, String errorCode, String message) {
+    private CustomResponse(boolean success, T data, String errorCode, String message) {
         this.success = success;
         this.data = data;
         this.errorCode = errorCode;
@@ -61,8 +61,8 @@ public class ApiResponse<T> {
      * 예시: ApiResponse.success(employee)
      * 결과: { "success": true, "data": {...} }
      */
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, data, null, null);
+    public static <T> CustomResponse<T> success(T data) {
+        return new CustomResponse<>(true, data, null, null);
     }
 
     /**
@@ -76,8 +76,8 @@ public class ApiResponse<T> {
      * 예시: ApiResponse.success(employee, "사원 등록 완료")
      * 결과: { "success": true, "data": {...}, "message": "사원 등록 완료" }
      */
-    public static <T> ApiResponse<T> success(T data, String message) {
-        return new ApiResponse<>(true, data, null, message);
+    public static <T> CustomResponse<T> success(T data, String message) {
+        return new CustomResponse<>(true, data, null, message);
     }
 
     /**
@@ -88,8 +88,8 @@ public class ApiResponse<T> {
      * 예시: ApiResponse.success()
      * 결과: { "success": true }
      */
-    public static ApiResponse<Void> success() {
-        return new ApiResponse<>(true, null, null, null);
+    public static CustomResponse<Void> success() {
+        return new CustomResponse<>(true, null, null, null);
     }
 
     /**
@@ -103,7 +103,7 @@ public class ApiResponse<T> {
      * 예시: ApiResponse.error("E001", "사원을 찾을 수 없습니다")
      * 결과: { "success": false, "errorCode": "E001", "message": "사원을 찾을 수 없습니다" }
      */
-    public static <T> ApiResponse<T> error(String errorCode, String message) {
-        return new ApiResponse<>(false, null, errorCode, message);
+    public static <T> CustomResponse<T> error(String errorCode, String message) {
+        return new CustomResponse<>(false, null, errorCode, message);
     }
 }

--- a/hero-be/src/main/java/com/c4/hero/domain/auth/controller/AuthController.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.c4.hero.domain.auth.controller;
 
-import com.c4.hero.common.response.ApiResponse;
+import com.c4.hero.common.response.CustomResponse;
 import com.c4.hero.domain.auth.service.AuthService;
 import com.c4.hero.domain.auth.security.JwtUtil;
 import jakarta.servlet.http.Cookie;
@@ -73,14 +73,14 @@ public class AuthController {
      * @return 새로 발급된 Access Token
      */
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<Map<String, String>>> refreshAccessToken(
+    public ResponseEntity<CustomResponse<Map<String, String>>> refreshAccessToken(
             @CookieValue(JwtUtil.REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
 
         String newAccessToken = authService.refreshAccessToken(refreshToken);
 
         // 새로 발급된 Access Token을 응답 본문에 담아 반환
         Map<String, String> responseBody = Map.of("accessToken", newAccessToken);
-        return ResponseEntity.ok(ApiResponse.success(responseBody));
+        return ResponseEntity.ok(CustomResponse.success(responseBody));
     }
 
     /**
@@ -90,10 +90,10 @@ public class AuthController {
      * @return 성공 메시지
      */
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
+    public ResponseEntity<CustomResponse<Void>> logout(HttpServletResponse response) {
         // Refresh Token이 담긴 쿠키를 만료시켜 클라이언트에서 삭제하도록 함
         response.addCookie(createExpiredCookie());
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(CustomResponse.success());
     }
 
     /**

--- a/hero-be/src/main/java/com/c4/hero/domain/employee/controller/EmployeeController.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/employee/controller/EmployeeController.java
@@ -1,6 +1,6 @@
 package com.c4.hero.domain.employee.controller;
 
-import com.c4.hero.common.response.ApiResponse;
+import com.c4.hero.common.response.CustomResponse;
 import com.c4.hero.common.response.PageResponse;
 import com.c4.hero.domain.auth.security.JwtUtil;
 import com.c4.hero.domain.employee.dto.response.EmployeeSearchOptionsResponseDTO;
@@ -64,9 +64,9 @@ public class EmployeeController {
      * @return 성공 시 ApiResponse<Void>
      */
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupRequestDTO request) {
+    public ResponseEntity<CustomResponse<Void>> signup(@Valid @RequestBody SignupRequestDTO request) {
         employeeCommandService.signup(request);
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(CustomResponse.success());
     }
 
     /**
@@ -76,9 +76,9 @@ public class EmployeeController {
      * @return 페이징된 직원 정보
      */
     @GetMapping("/search")
-    public ResponseEntity<ApiResponse<PageResponse<EmployeeListResponseDTO>>> search(@ModelAttribute EmployeeSearchDTO searchDTO) {
+    public ResponseEntity<CustomResponse<PageResponse<EmployeeListResponseDTO>>> search(@ModelAttribute EmployeeSearchDTO searchDTO) {
         PageResponse<EmployeeListResponseDTO> result = employeeQueryService.getEmployees(searchDTO);
-        return ResponseEntity.ok(ApiResponse.success(result));
+        return ResponseEntity.ok(CustomResponse.success(result));
     }
 
 
@@ -88,9 +88,9 @@ public class EmployeeController {
      * @return 검색 옵션 목록
      */
     @GetMapping("/search-options")
-    public ResponseEntity<ApiResponse<EmployeeSearchOptionsResponseDTO>> getEmployeeSearchOptions() {
+    public ResponseEntity<CustomResponse<EmployeeSearchOptionsResponseDTO>> getEmployeeSearchOptions() {
         EmployeeSearchOptionsResponseDTO result = employeeQueryService.getEmployeeSearchOptions();
-        return ResponseEntity.ok(ApiResponse.success(result));
+        return ResponseEntity.ok(CustomResponse.success(result));
     }
 
 
@@ -101,9 +101,9 @@ public class EmployeeController {
      * @return 직원의 상세 정보
      */
     @GetMapping("/{employeeId}")
-    public ResponseEntity<ApiResponse<EmployeeDetailResponseDTO>> getEmployeeDetail(@PathVariable Integer employeeId) {
+    public ResponseEntity<CustomResponse<EmployeeDetailResponseDTO>> getEmployeeDetail(@PathVariable Integer employeeId) {
         EmployeeDetailResponseDTO result = employeeQueryService.findById(employeeId);
-        return ResponseEntity.ok(ApiResponse.success(result));
+        return ResponseEntity.ok(CustomResponse.success(result));
     }
 
     /**
@@ -113,40 +113,40 @@ public class EmployeeController {
      * @return 본인 정보
      */
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<MyInfoResponseDTO>> getMyInfo(HttpServletRequest request) {
+    public ResponseEntity<CustomResponse<MyInfoResponseDTO>> getMyInfo(HttpServletRequest request) {
         String token = jwtUtil.resolveToken(request);
         Integer currentEmployeeId = jwtUtil.getEmployeeId(token);
         MyInfoResponseDTO result = employeeQueryService.getMyInfo(currentEmployeeId);
-        return ResponseEntity.ok(ApiResponse.success(result));
+        return ResponseEntity.ok(CustomResponse.success(result));
     }
 
     /**
      * 직원 정보 수정 (인사 직원 사용)
      */
     @PutMapping("/{employeeId}")
-    public ResponseEntity<ApiResponse<Void>> updateEmployee(HttpServletRequest request, @PathVariable Integer employeeId, @RequestBody EmployeeUpdateRequestDTO requestDTO) {
+    public ResponseEntity<CustomResponse<Void>> updateEmployee(HttpServletRequest request, @PathVariable Integer employeeId, @RequestBody EmployeeUpdateRequestDTO requestDTO) {
         String token = jwtUtil.resolveToken(request);
         // TODO: 토큰에서 사용자 정보(관리자 권한) 확인
         // employeeCommandService.updateEmployee(employeeId, requestDTO);
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(CustomResponse.success());
     }
 
     /**
      * 직원 정보 수정 (본인 사용)
      */
     @PutMapping("/me")
-    public ResponseEntity<ApiResponse<Void>> selfUpdateEmployee(HttpServletRequest request, @RequestBody EmployeeSelfUpdateRequestDTO requestDTO) {
+    public ResponseEntity<CustomResponse<Void>> selfUpdateEmployee(HttpServletRequest request, @RequestBody EmployeeSelfUpdateRequestDTO requestDTO) {
         String token = jwtUtil.resolveToken(request);
         Integer currentEmployeeId = jwtUtil.getEmployeeId(token);
         // employeeCommandService.selfUpdateEmployee(currentEmployeeId, requestDTO);
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(CustomResponse.success());
     }
 
     /**
      * 퇴사한 사람들
      */
     @GetMapping("/leave")
-    public ResponseEntity<ApiResponse<EmployeeListResponseDTO>> getResignedEmployees() {
+    public ResponseEntity<CustomResponse<EmployeeListResponseDTO>> getResignedEmployees() {
 
         //
         return null;
@@ -156,16 +156,16 @@ public class EmployeeController {
      * 직원 퇴사 처리
      */
     @DeleteMapping("/{employeeId}")
-    public ResponseEntity<ApiResponse<Void>> terminateEmployee(@PathVariable Integer employeeId) {
+    public ResponseEntity<CustomResponse<Void>> terminateEmployee(@PathVariable Integer employeeId) {
         // employeeCommandService.terminateEmployee(employeeId);
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(CustomResponse.success());
     }
 
     /**
      * 로그인 로그 확인
      */
     @GetMapping("/login-log/{employeeId}")
-    public ResponseEntity<ApiResponse<List<LoginHistoryResponseDTO>>> getLoginHistory(@PathVariable Integer employeeId) {
+    public ResponseEntity<CustomResponse<List<LoginHistoryResponseDTO>>> getLoginHistory(@PathVariable Integer employeeId) {
         // List<LoginHistoryResponseDTO> history = employeeQueryService.getLoginHistory(employeeId);
         // return ResponseEntity.ok(ApiResponse.success(history));
         return null; // 임시
@@ -175,7 +175,7 @@ public class EmployeeController {
      * 부서 이동 로그 확인
      */
     @GetMapping("/department-log/{employeeId}")
-    public ResponseEntity<ApiResponse<List<DepartmentHistoryResponseDTO>>> getDepartmentHistory(@PathVariable Integer employeeId) {
+    public ResponseEntity<CustomResponse<List<DepartmentHistoryResponseDTO>>> getDepartmentHistory(@PathVariable Integer employeeId) {
         // List<DepartmentHistoryResponseDTO> history = employeeQueryService.getDepartmentHistory(employeeId);
         // return ResponseEntity.ok(ApiResponse.success(history));
         return null; // 임시
@@ -185,7 +185,7 @@ public class EmployeeController {
      * 직급 로그 확인
      */
     @GetMapping("/grade-log/{employeeId}")
-    public ResponseEntity<ApiResponse<List<GradeHistoryResponseDTO>>> getGradeHistory(@PathVariable Integer employeeId) {
+    public ResponseEntity<CustomResponse<List<GradeHistoryResponseDTO>>> getGradeHistory(@PathVariable Integer employeeId) {
         // List<GradeHistoryResponseDTO> history = employeeQueryService.getGradeHistory(employeeId);
         // return ResponseEntity.ok(ApiResponse.success(history));
         return null; // 임시
@@ -199,9 +199,9 @@ public class EmployeeController {
      * EmployeePasswordChangeServicec에서 처리
      */
     @PostMapping("/change-password-auth")
-    public ResponseEntity<ApiResponse<Void>> authChangePassword(@Valid @RequestBody SignupRequestDTO request) {
+    public ResponseEntity<CustomResponse<Void>> authChangePassword(@Valid @RequestBody SignupRequestDTO request) {
         // passwordChangeService.sendAuthCode(request.getEmail());
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(CustomResponse.success());
     }
 
     /**
@@ -210,8 +210,8 @@ public class EmployeeController {
      * EmployeePasswordChangeServicec에서 처리
      */
     @PostMapping("/change-password")
-    public ResponseEntity<ApiResponse<Void>> changePassword(@Valid @RequestBody PasswordChangeRequestDTO request) {
+    public ResponseEntity<CustomResponse<Void>> changePassword(@Valid @RequestBody PasswordChangeRequestDTO request) {
         // passwordChangeService.changePassword(request);
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(CustomResponse.success());
     }
 }

--- a/hero-be/src/main/java/com/c4/hero/domain/employee/entity/Grade.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/employee/entity/Grade.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,11 +23,14 @@ import lombok.Setter;
  * @author 이승건
  * @version 1.0
  */
+
+@Builder
 @Entity
 @Table(name = "tbl_grade")
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class Grade {
 
     /**

--- a/hero-be/src/main/java/com/c4/hero/domain/employee/repository/EmployeeDepartmentRepository.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/employee/repository/EmployeeDepartmentRepository.java
@@ -3,6 +3,7 @@ package com.c4.hero.domain.employee.repository;
 import com.c4.hero.domain.employee.entity.EmployeeDepartment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -11,7 +12,8 @@ import java.util.Optional;
  * Description: Department 엔티티에 대한 데이터 접근을 위한 Repository
  *
  * History
- * 2025/12/09 이승건 최초 작성
+ * 2025/12/09 승건 최초 작성
+ * 2025/12/19 승건 상위 부서의 ID를 기준으로 조회하는 메소드 추가
  * </pre>
  *
  * @author 이승건
@@ -20,10 +22,18 @@ import java.util.Optional;
 public interface EmployeeDepartmentRepository extends JpaRepository<EmployeeDepartment, Integer> {
 
     /**
-     * 부서 이름으로 부서 엔티티 조회
+     * 부서 이름으로 부서 엔티티를 조회합니다.
      *
      * @param departmentName 부서 이름
-     * @return Optional<Department>
+     * @return Optional<EmployeeDepartment>
      */
     Optional<EmployeeDepartment> findByDepartmentName(String departmentName);
+
+    /**
+     * 주어진 상위 부서 ID에 속하는 모든 직속 하위 부서 목록을 조회합니다.
+     *
+     * @param parentDepartmentId 상위 부서 ID
+     * @return 하위 부서 엔티티 목록
+     */
+    List<EmployeeDepartment> findByParentDepartmentId(Integer parentDepartmentId);
 }

--- a/hero-be/src/main/java/com/c4/hero/domain/employee/repository/EmployeeRepository.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/employee/repository/EmployeeRepository.java
@@ -15,7 +15,8 @@ import java.util.Optional;
  * Description: Employee 엔티티에 대한 데이터 접근을 위한 Repository
  *
  * History
- * 2025/12/09 이승건 최초 작성
+ * 2025/12/09 승건 최초 작성
+ * 2025/12/19 승건 승진 후보자 조회 추가
  * </pre>
  *
  * @author 이승건
@@ -43,11 +44,48 @@ public interface EmployeeRepository extends JpaRepository<Employee, Integer> {
     @Query("UPDATE Employee e SET e.employeeDepartment.departmentId = :newDepartmentId WHERE e.employeeDepartment.departmentId IN :oldDepartmentIds")
     void updateDepartmentByDepartmentIds(@Param("newDepartmentId") Integer newDepartmentId, @Param("oldDepartmentIds") List<Integer> oldDepartmentIds);
 
+    /**
+     * 주어진 부서 ID 목록에 속하는 모든 직원을 조회합니다.
+     *
+     * @param departmentIds 부서 ID 목록
+     * @return 직원 목록
+     */
     List<Employee> findAllByEmployeeDepartment_DepartmentIdIn(List<Integer> departmentIds);
 
+    /**
+     * 주어진 직급 ID 목록에 속하는 모든 직원을 조회합니다.
+     *
+     * @param gradeIds 직급 ID 목록
+     * @return 직원 목록
+     */
     List<Employee> findAllByGrade_GradeIdIn(List<Integer> gradeIds);
 
+    /**
+     * 주어진 직급 ID 목록에 속한 모든 직원의 직급을 null로 일괄 업데이트합니다.
+     *
+     * @param gradeIds 변경 대상이 되는 기존 직급 ID 목록
+     */
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Employee e SET e.grade = null WHERE e.grade.gradeId IN :gradeIds")
     void updateGradeByGradeIds(@Param("gradeIds") List<Integer> gradeIds);
+
+    /**
+     * 조건에 맞는 승진 후보자들을 조회합니다.
+     *
+     * @param departmentIds    후보자가 속한 부서 ID 목록 (하위 부서 포함)
+     * @param candidateGradeId 후보자의 현재 직급 ID
+     * @param requiredPoint    승진에 필요한 최소 평가 점수
+     * @return 조건에 맞는 직원 목록 (평가 점수 내림차순 정렬)
+     */
+    @Query("SELECT e " +
+            " FROM Employee e " +
+            "WHERE e.employeeDepartment.departmentId IN :departmentIds " +
+            "  AND e.grade.gradeId = :candidateGradeId " +
+            "  AND e.evaluationPoint >= :requiredPoint " +
+            "ORDER BY e.evaluationPoint DESC")
+    List<Employee> findPromotionCandidates(
+            @Param("departmentIds") List<Integer> departmentIds,
+            @Param("candidateGradeId") Integer candidateGradeId,
+            @Param("requiredPoint") Integer requiredPoint
+    );
 }

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/controller/PromotionController.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/controller/PromotionController.java
@@ -1,0 +1,93 @@
+package com.c4.hero.domain.promotion.controller;
+
+import com.c4.hero.common.response.CustomResponse;
+import com.c4.hero.common.response.PageResponse;
+import com.c4.hero.domain.promotion.dto.request.PromotionPlanRequestDTO;
+import com.c4.hero.domain.promotion.dto.response.PromotionOptionsDTO;
+import com.c4.hero.domain.promotion.dto.response.PromotionPlanDetailResponseDTO;
+import com.c4.hero.domain.promotion.dto.response.PromotionPlanResponseDTO;
+import com.c4.hero.domain.promotion.service.PromotionCommandService;
+import com.c4.hero.domain.promotion.service.PromotionQueryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * <pre>
+ * Class Name: PromotionController
+ * Description: 승진 관련 API 요청을 처리하는 컨트롤러
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+@RestController
+@RequestMapping("/api/promotion")
+@RequiredArgsConstructor
+public class PromotionController {
+
+    private final PromotionCommandService promotionCommandService;
+    private final PromotionQueryService promotionQueryService;
+
+    /**
+     * 새로운 승진 계획을 등록합니다.
+     *
+     * @param request 등록할 승진 계획 정보
+     * @return 성공 응답
+     */
+    @PostMapping("/plan")
+    public ResponseEntity<CustomResponse<Void>> registerPromotionPlan(@Valid @RequestBody PromotionPlanRequestDTO request) {
+        promotionCommandService.registerPromotionPlan(request);
+        return ResponseEntity.ok(CustomResponse.success());
+    }
+
+    /**
+     * 승진 계획 목록을 페이징하여 조회합니다.
+     *
+     * @param isFinished 조회할 계획의 완료 여부 (true: 완료, false: 진행중, null: 전체)
+     * @param pageable   페이징 정보 (ex: ?page=0&size=10)
+     * @return 페이징된 승진 계획 목록
+     */
+    @GetMapping("/plan")
+    public ResponseEntity<CustomResponse<PageResponse<PromotionPlanResponseDTO>>> getPromotionPlan(
+            @RequestParam(required = false) Boolean isFinished,
+            Pageable pageable) {
+        PageResponse<PromotionPlanResponseDTO> response = promotionQueryService.getPromotionPlan(isFinished, pageable);
+        return ResponseEntity.ok(CustomResponse.success(response));
+    }
+
+    /**
+     * 승진 계획의 상세 정보를 조회합니다.
+     *
+     * @param promotionId 조회할 승진 계획의 ID
+     * @return 승진 계획 상세 정보
+     */
+    @GetMapping("/plan/{promotionId}")
+    public ResponseEntity<CustomResponse<PromotionPlanDetailResponseDTO>> getPromotionPlanDetail(
+            @PathVariable int promotionId) {
+        PromotionPlanDetailResponseDTO response = promotionQueryService.getPromotionPlanDetail(promotionId);
+        return ResponseEntity.ok(CustomResponse.success(response));
+    }
+
+    /**
+     * 승진 계획 등록에 필요한 옵션(부서, 직급)을 조회합니다.
+     *
+     * @return 부서 트리 구조와 직급 목록
+     */
+    @GetMapping("/plan/options")
+    public ResponseEntity<CustomResponse<PromotionOptionsDTO>> getPromotionOptions() {
+        PromotionOptionsDTO response = promotionQueryService.getPromotionOptions();
+        return ResponseEntity.ok(CustomResponse.success(response));
+    }
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/PromotionCandidateDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/PromotionCandidateDTO.java
@@ -1,0 +1,38 @@
+package com.c4.hero.domain.promotion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * <pre>
+ * Class Name: PromotionCandidateDTO
+ * Description: 승진 후보자 정보를 담는 DTO
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+
+@Builder
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionCandidateDTO {
+    private Integer employeeId;         // 승진 후보자 ID
+    private String employeeName;        // 승진 후보자 이름
+    private String employeeNumber;      // 승진 후보자 사번
+    private String department;          // 승진 후보자 부서
+    private String grade;               // 승진 후보자 직급
+    private String nominatorName;       // 추천인 이름
+    private String nominationReason;    // 추천 사유
+    private Boolean isApproved;         // 승인 여부
+    private String rejectionReason;     // 반려 사유
+    private Integer evaluationPoint;    // 평가 포인트
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/PromotionDepartmentDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/PromotionDepartmentDTO.java
@@ -1,0 +1,55 @@
+package com.c4.hero.domain.promotion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <pre>
+ * Class Name: PromotionDepartmentDTO
+ * Description: 승진 계획 옵션 중 부서 정보를 트리 구조로 담는 DTO
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionDepartmentDTO {
+
+    /**
+     * 부서 ID
+     */
+    private Integer departmentId;
+
+    /**
+     * 부서명
+     */
+    private String departmentName;
+
+    /**
+     * 하위 부서 목록
+     */
+    @Builder.Default
+    private List<PromotionDepartmentDTO> children = new ArrayList<>();
+
+    /**
+     * 하위 부서를 추가하는 편의 메소드
+     *
+     * @param child 하위 부서 DTO
+     */
+    public void addChild(PromotionDepartmentDTO child) {
+        this.children.add(child);
+    }
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/PromotionDetailPlanDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/PromotionDetailPlanDTO.java
@@ -1,0 +1,35 @@
+package com.c4.hero.domain.promotion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+/**
+ * <pre>
+ * Class Name: PromotionDetailPlanDTO
+ * Description: 승진 상세 계획 정보를 담는 DTO
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PromotionDetailPlanDTO {
+    private Integer departmentId;       // 승진 대상 부서 ID
+    private String department;          // 승진 대상 부서명
+    private Integer gradeId;            // 승진 후 직급 ID
+    private String grade;               // 승진 후 직급명
+    private Integer quotaCount;         // TO
+    private List<PromotionCandidateDTO> candidateList;
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/PromotionGradeDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/PromotionGradeDTO.java
@@ -1,0 +1,30 @@
+package com.c4.hero.domain.promotion.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * <pre>
+ * Class Name: PromotionGradeDTO
+ * Description: 승진 계획에 사용할 수 있는 직급을 제공하기 위한 DTO
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author `승건
+ * @version 1.0
+ */
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PromotionGradeDTO {
+    private Integer gradeId;
+    private String grade;
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/request/PromotionPlanRequestDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/request/PromotionPlanRequestDTO.java
@@ -1,0 +1,66 @@
+package com.c4.hero.domain.promotion.dto.request;
+
+import com.c4.hero.domain.promotion.dto.PromotionDetailPlanDTO;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * <pre>
+ * Class Name: PromotionPlanRequestDTO
+ * Description: 승진 계획 등록을 위한 요청 DTO
+ *
+ * History
+ * 2025-12-19 (이승건) 최초 작성
+ * </pre>
+ *
+ * @author 이승건
+ * @version 1.0
+ */
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionPlanRequestDTO {
+
+    /**
+     * 승진 계획명
+     */
+    @NotBlank(message = "계획명은 필수입니다.")
+    private String planName;
+
+    /**
+     * 추천 마감일
+     */
+    @NotNull(message = "추천 마감일은 필수입니다.")
+    @Future(message = "추천 마감일은 현재보다 미래여야 합니다.")
+    private LocalDate nominationDeadlineAt;
+
+    /**
+     * 발령일
+     */
+    @NotNull(message = "발령일은 필수입니다.")
+    @Future(message = "발령일은 현재보다 미래여야 합니다.")
+    private LocalDate appointmentAt;
+
+    /**
+     * 상세 계획 목록
+     */
+    @NotEmpty(message = "상세 계획은 최소 1개 이상 포함되어야 합니다.")
+    private List<PromotionDetailPlanDTO> detailPlan;
+
+    /**
+     * 계획 관련 추가 내용
+     */
+    private String planContent;
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/response/PromotionOptionsDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/response/PromotionOptionsDTO.java
@@ -1,0 +1,35 @@
+package com.c4.hero.domain.promotion.dto.response;
+
+
+import com.c4.hero.domain.promotion.dto.PromotionDepartmentDTO;
+import com.c4.hero.domain.promotion.dto.PromotionGradeDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+/**
+ * <pre>
+ * Class Name: PromotionOptionsDTO
+ * Description: 승진 계획에서 선택할 수 있는 옵션을 제공하기 위한 DTO(부서, 직급)
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author `승건
+ * @version 1.0
+ */
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PromotionOptionsDTO {
+    private List<PromotionDepartmentDTO> promotionDepartmentDTOList;
+    private List<PromotionGradeDTO> promotionGradeDTOList;
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/response/PromotionPlanDetailResponseDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/response/PromotionPlanDetailResponseDTO.java
@@ -1,0 +1,40 @@
+package com.c4.hero.domain.promotion.dto.response;
+
+import com.c4.hero.domain.promotion.dto.PromotionDetailPlanDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * <pre>
+ * Class Name: PromotionPlanDetailResponseDTO
+ * Description: 승진 계획 상세 조회를 위한 응답 DTO
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author `승건
+ * @version 1.0
+ */
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PromotionPlanDetailResponseDTO {
+    private Integer promotionId;
+    private String planName;                           // 승진 계획 제목 -> 전자 결제 제목 그대로 사용
+    private LocalDateTime createdAt;                    // 생성일
+    private LocalDate nominationDeadlineAt;             // 추천 마감일
+    private LocalDate appointmentAt;                    // 발령일
+    private List<PromotionDetailPlanDTO> detailPlan;    // 상세 계획 - 여기를 null로 주냐 값을 주냐에 따라 기본 조회와 상세 조회로 구분
+    private String planContent;
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/response/PromotionPlanResponseDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/dto/response/PromotionPlanResponseDTO.java
@@ -1,0 +1,36 @@
+package com.c4.hero.domain.promotion.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * <pre>
+ * Class Name: PromotionPlanResponseDTO
+ * Description: 승진 계획 목록 조회를 위한 응답 DTO
+ *
+ * History
+ * 2025/12/18 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PromotionPlanResponseDTO {
+    private Integer promotionId;
+    private String planName;                           // 승진 계획 제목 -> 전자 결제 제목 그대로 사용
+    private LocalDateTime createdAt;                    // 생성일
+    private LocalDate nominationDeadlineAt;             // 추천 마감일
+    private LocalDate appointmentAt;                    // 발령일
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/entity/PromotionCandidate.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/entity/PromotionCandidate.java
@@ -1,0 +1,92 @@
+package com.c4.hero.domain.promotion.entity;
+
+import com.c4.hero.domain.employee.entity.Employee;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * <pre>
+ * Class Name: PromotionCandidate
+ * Description: 승진 후보자 정보를 담는 엔티티
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+@Entity
+@Table(name = "tbl_promotion_candidate")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionCandidate {
+
+    /**
+     * 후보자 ID (PK)
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "candidate_id")
+    private Integer candidateId;
+
+    /**
+     * 상위 승진 상세 계획
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "promotion_detail_id", nullable = false)
+    private PromotionDetail promotionDetail;
+
+    /**
+     * 후보자 직원 정보
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id", nullable = false)
+    private Employee employee;
+
+    /**
+     * 추천인 직원 정보
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "nominator_id")
+    private Employee nominator;
+
+    /**
+     * 추천 사유
+     */
+    @Column(name = "nomination_reason", columnDefinition = "TEXT")
+    private String nominationReason;
+
+    /**
+     * 승인 여부
+     */
+    @Column(name = "is_approved")
+    private Boolean isApproved;
+
+    /**
+     * 반려 사유
+     */
+    @Column(name = "rejection_reason", columnDefinition = "TEXT")
+    private String rejectionReason;
+
+    /**
+     * 후보자 등록 당시의 평가 점수
+     */
+    @Column(name = "evaluation_point", nullable = false)
+    private Integer evaluationPoint;
+
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/entity/PromotionDetail.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/entity/PromotionDetail.java
@@ -1,0 +1,88 @@
+package com.c4.hero.domain.promotion.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * <pre>
+ * Class Name: PromotionDetail
+ * Description: 승진 상세 계획 정보를 담는 엔티티
+ *
+ * History
+ * 2025-12-19 (이승건) 최초 작성
+ * </pre>
+ *
+ * @author 이승건
+ * @version 1.0
+ */
+@Entity
+@Table(name = "tbl_promotion_detail")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionDetail {
+
+    /**
+     * 승진 상세 계획 ID (PK)
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "promotion_detail_id")
+    private Integer promotionDetailId;
+
+    /**
+     * 상위 승진 계획
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "promotion_plan_id", nullable = false)
+    private PromotionPlan promotionPlan;
+
+    /**
+     * 대상 부서 ID
+     */
+    @Column(name = "department_id", nullable = false)
+    private Integer departmentId;
+
+    /**
+     * 대상 직급 ID
+     */
+    @Column(name = "grade_id", nullable = false)
+    private Integer gradeId;
+
+    /**
+     * 생성 일시
+     */
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * 수정 일시
+     */
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /**
+     * 승진 TO (인원수)
+     */
+    @Column(name = "quota_count")
+    private Integer quotaCount;
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/entity/PromotionPlan.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/entity/PromotionPlan.java
@@ -1,0 +1,76 @@
+package com.c4.hero.domain.promotion.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * <pre>
+ * Class Name: PromotionPlan
+ * Description: 승진 계획 정보를 담는 엔티티
+ *
+ * History
+ * 2025-12-19 (이승건) 최초 작성
+ * </pre>
+ *
+ * @author 이승건
+ * @version 1.0
+ */
+@Builder
+@Entity
+@Table(name = "tbl_promotion_plan")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromotionPlan {
+
+    /**
+     * 승진 계획 ID (PK)
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "promotion_plan_id")
+    private Integer promotionPlanId;
+
+    /**
+     * 승진 계획명
+     */
+    @Column(name = "plan_name", nullable = false, length = 50)
+    private String planName;
+
+    /**
+     * 생성 일시
+     */
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * 추천 마감일
+     */
+    @Column(name = "nomination_deadline_at", nullable = false)
+    private LocalDate nominationDeadlineAt;
+
+    /**
+     * 발령일
+     */
+    @Column(name = "appointment_at", nullable = false)
+    private LocalDate appointmentAt;
+
+    /**
+     * 계획 관련 추가 내용
+     */
+    @Column(name = "plan_content", columnDefinition = "TEXT")
+    private String planContent;
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/mapper/PromotionMapper.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/mapper/PromotionMapper.java
@@ -1,0 +1,50 @@
+package com.c4.hero.domain.promotion.mapper;
+
+import com.c4.hero.domain.promotion.dto.response.PromotionPlanDetailResponseDTO;
+import com.c4.hero.domain.promotion.dto.response.PromotionPlanResponseDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * <pre>
+ * Interface Name: PromotionMapper
+ * Description: 승진 관련 데이터베이스 접근을 위한 MyBatis 매퍼 인터페이스
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+@Mapper
+public interface PromotionMapper {
+
+    /**
+     * 조건에 맞는 승진 계획 목록을 페이징하여 조회합니다.
+     *
+     * @param isFinished 완료 여부 (true: 완료, false: 진행중, null: 전체)
+     * @param offset     페이지 오프셋
+     * @param limit      페이지당 개수
+     * @return 승진 계획 목록
+     */
+    List<PromotionPlanResponseDTO> selectPromotionPlan(@Param("isFinished") Boolean isFinished, @Param("offset") int offset, @Param("limit") int limit);
+
+    /**
+     * 조건에 맞는 승진 계획의 전체 개수를 조회합니다.
+     *
+     * @param isFinished 완료 여부 (true: 완료, false: 진행중, null: 전체)
+     * @return 전체 개수
+     */
+    long countPromotionPlan(@Param("isFinished") Boolean isFinished);
+
+    /**
+     * 특정 승진 계획의 상세 정보를 조회합니다.
+     *
+     * @param promotionId 조회할 승진 계획 ID
+     * @return 승진 계획 상세 정보 (하위 계획 포함)
+     */
+    PromotionPlanDetailResponseDTO selectPromotionPlanDetail(int promotionId);
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/repotiroy/PromotionCandidateRepository.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/repotiroy/PromotionCandidateRepository.java
@@ -1,0 +1,19 @@
+package com.c4.hero.domain.promotion.repotiroy;
+
+import com.c4.hero.domain.promotion.entity.PromotionCandidate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * <pre>
+ * Interface Name: PromotionCandidateRepository
+ * Description: PromotionCandidate 엔티티에 대한 데이터 접근을 위한 Repository
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+public interface PromotionCandidateRepository extends JpaRepository<PromotionCandidate, Integer> {
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/repotiroy/PromotionDetailRepository.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/repotiroy/PromotionDetailRepository.java
@@ -1,0 +1,19 @@
+package com.c4.hero.domain.promotion.repotiroy;
+
+import com.c4.hero.domain.promotion.entity.PromotionDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * <pre>
+ * Interface Name: PromotionDetailRepository
+ * Description: PromotionDetail 엔티티에 대한 데이터 접근을 위한 Repository
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+public interface PromotionDetailRepository extends JpaRepository<PromotionDetail, Integer> {
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/repotiroy/PromotionPlanRepository.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/repotiroy/PromotionPlanRepository.java
@@ -1,0 +1,19 @@
+package com.c4.hero.domain.promotion.repotiroy;
+
+import com.c4.hero.domain.promotion.entity.PromotionPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * <pre>
+ * Interface Name: PromotionPlanRepository
+ * Description: PromotionPlan 엔티티에 대한 데이터 접근을 위한 Repository
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+public interface PromotionPlanRepository extends JpaRepository<PromotionPlan, Integer> {
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/service/PromotionCommandService.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/service/PromotionCommandService.java
@@ -1,0 +1,183 @@
+package com.c4.hero.domain.promotion.service;
+
+import com.c4.hero.common.exception.BusinessException;
+import com.c4.hero.common.exception.ErrorCode;
+import com.c4.hero.domain.employee.entity.Employee;
+import com.c4.hero.domain.employee.entity.EmployeeDepartment;
+import com.c4.hero.domain.employee.entity.Grade;
+import com.c4.hero.domain.employee.repository.EmployeeDepartmentRepository;
+import com.c4.hero.domain.employee.repository.EmployeeGradeRepository;
+import com.c4.hero.domain.employee.repository.EmployeeRepository;
+import com.c4.hero.domain.promotion.dto.PromotionDetailPlanDTO;
+import com.c4.hero.domain.promotion.dto.request.PromotionPlanRequestDTO;
+import com.c4.hero.domain.promotion.entity.PromotionCandidate;
+import com.c4.hero.domain.promotion.entity.PromotionDetail;
+import com.c4.hero.domain.promotion.entity.PromotionPlan;
+import com.c4.hero.domain.promotion.repotiroy.PromotionCandidateRepository;
+import com.c4.hero.domain.promotion.repotiroy.PromotionDetailRepository;
+import com.c4.hero.domain.promotion.repotiroy.PromotionPlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * <pre>
+ * Class Name: PromotionCommandService
+ * Description: 승진 관련 CUD(생성, 수정, 삭제) 비즈니스 로직을 처리하는 서비스
+ *
+ * History
+ * 2025/12/19 승건 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PromotionCommandService {
+
+    private final PromotionPlanRepository promotionPlanRepository;
+    private final PromotionDetailRepository promotionDetailRepository;
+    private final PromotionCandidateRepository promotionCandidateRepository;
+    private final EmployeeRepository employeeRepository;
+    private final EmployeeGradeRepository gradeRepository;
+    private final EmployeeDepartmentRepository departmentRepository;
+
+    private final ModelMapper modelMapper;
+
+    /**
+     * 새로운 승진 계획을 등록하고, 조건에 맞는 후보자를 자동으로 등록합니다.
+     *
+     * @param request 등록할 승진 계획 정보
+     */
+    public void registerPromotionPlan(PromotionPlanRequestDTO request) {
+        // 1. 요청 값 유효성 검증
+        validatePromotionPlan(request);
+
+        // 2. 승진 계획 엔티티 생성 및 저장
+        PromotionPlan promotionPlan = PromotionPlan.builder()
+                .planName(request.getPlanName())
+                .nominationDeadlineAt(request.getNominationDeadlineAt())
+                .appointmentAt(request.getAppointmentAt())
+                .planContent(request.getPlanContent())
+                .build();
+        PromotionPlan savedPlan = promotionPlanRepository.save(promotionPlan);
+
+        // 3. 상세 계획 저장 및 후보자 자동 등록
+        for (PromotionDetailPlanDTO detailDTO : request.getDetailPlan()) {
+            PromotionDetail promotionDetail = PromotionDetail.builder()
+                    .promotionPlan(savedPlan)
+                    .departmentId(detailDTO.getDepartmentId())
+                    .gradeId(detailDTO.getGradeId())
+                    .quotaCount(detailDTO.getQuotaCount())
+                    .build();
+            PromotionDetail savedDetail = promotionDetailRepository.save(promotionDetail);
+
+            // 4. 조건에 맞는 후보자 자동 등록
+            autoRegisterCandidates(savedDetail);
+        }
+    }
+
+    /**
+     * 승진 계획 요청 값의 비즈니스 규칙을 검증합니다.
+     *
+     * @param request 검증할 승진 계획 요청
+     */
+    private void validatePromotionPlan(PromotionPlanRequestDTO request) {
+        // 추천 마감일은 발령일보다 이전이어야 함
+        if (request.getNominationDeadlineAt().isAfter(request.getAppointmentAt())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "추천 마감일은 발령일보다 이전이어야 합니다.");
+        }
+        // 상세 계획은 최소 1개 이상 포함되어야 함
+        if (CollectionUtils.isEmpty(request.getDetailPlan())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "승진 상세 계획은 최소 1개 이상 포함되어야 합니다.");
+        }
+    }
+
+    /**
+     * 승진 상세 계획에 따라 조건에 맞는 후보자를 자동으로 찾아 등록합니다.
+     *
+     * @param promotionDetail 후보자를 등록할 승진 상세 계획
+     */
+    private void autoRegisterCandidates(PromotionDetail promotionDetail) {
+        Integer targetGradeId = promotionDetail.getGradeId();
+
+        // 1. 모든 직급 정보 조회 및 정렬
+        List<Grade> allGrades = gradeRepository.findAll(Sort.by("gradeId"));
+
+        // 2. 승진 대상 직급의 바로 아래 직급과 필요 포인트 탐색
+        Grade candidateGrade = null;
+        Integer requiredPoint = null;
+
+        for (int i = 0; i < allGrades.size(); i++) {
+            Grade currentGrade = allGrades.get(i);
+            if (currentGrade.getGradeId().equals(targetGradeId)) {
+                requiredPoint = currentGrade.getRequiredPoint();
+                if (i > 1) { // index 0(관리자), 1(사원)은 승진 후보가 될 수 없음
+                    candidateGrade = allGrades.get(i - 1);
+                }
+                break;
+            }
+        }
+
+        // 3. 예외 처리
+        if (requiredPoint == null) {
+            throw new BusinessException(ErrorCode.GRADE_NOT_FOUND, "승진 대상 직급 정보를 찾을 수 없습니다.");
+        }
+        if (candidateGrade == null) {
+            throw new BusinessException(ErrorCode.INVALID_PROMOTION_TARGET_GRADE, "해당 직급으로는 승진 계획을 생성할 수 없습니다.");
+        }
+
+        // 4. 대상 부서 및 모든 하위 부서 ID 조회
+        List<Integer> departmentIds = findAllSubDepartmentIds(promotionDetail.getDepartmentId());
+
+        // 5. 조건에 맞는 승진 후보 직원 조회
+        List<Employee> candidates = employeeRepository.findPromotionCandidates(
+                departmentIds,
+                candidateGrade.getGradeId(),
+                requiredPoint
+        );
+
+        // 6. 조회된 후보자들을 PromotionCandidate 엔티티로 변환하여 저장
+        if (!CollectionUtils.isEmpty(candidates)) {
+            List<PromotionCandidate> promotionCandidates = candidates.stream()
+                    .map(employee -> PromotionCandidate.builder()
+                            .promotionDetail(promotionDetail)
+                            .employee(employee)
+                            .evaluationPoint(employee.getEvaluationPoint())
+                            .build())
+                    .collect(Collectors.toList());
+            promotionCandidateRepository.saveAll(promotionCandidates);
+        }
+    }
+
+    /**
+     * 지정된 부서 ID와 그 아래 모든 하위 부서의 ID 목록을 재귀적으로 조회합니다.
+     *
+     * @param departmentId 최상위 부서 ID
+     * @return 자기 자신을 포함한 모든 하위 부서 ID 목록
+     */
+    private List<Integer> findAllSubDepartmentIds(Integer departmentId) {
+        List<Integer> allSubDepartments = new ArrayList<>();
+        allSubDepartments.add(departmentId); // 자기 자신 포함
+
+        List<EmployeeDepartment> directChildren = departmentRepository.findByParentDepartmentId(departmentId);
+        List<Integer> directChildrenIds = directChildren.stream()
+                .map(EmployeeDepartment::getDepartmentId)
+                .toList();
+
+        for (Integer childId : directChildrenIds) {
+            allSubDepartments.addAll(findAllSubDepartmentIds(childId));
+        }
+
+        return allSubDepartments;
+    }
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/promotion/service/PromotionQueryService.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/promotion/service/PromotionQueryService.java
@@ -1,0 +1,169 @@
+package com.c4.hero.domain.promotion.service;
+
+import com.c4.hero.common.exception.BusinessException;
+import com.c4.hero.common.exception.ErrorCode;
+import com.c4.hero.common.response.PageResponse;
+import com.c4.hero.domain.employee.entity.EmployeeDepartment;
+import com.c4.hero.domain.employee.entity.Grade;
+import com.c4.hero.domain.employee.repository.EmployeeDepartmentRepository;
+import com.c4.hero.domain.employee.repository.EmployeeGradeRepository;
+import com.c4.hero.domain.promotion.dto.PromotionDepartmentDTO;
+import com.c4.hero.domain.promotion.dto.PromotionGradeDTO;
+import com.c4.hero.domain.promotion.dto.response.PromotionOptionsDTO;
+import com.c4.hero.domain.promotion.dto.response.PromotionPlanDetailResponseDTO;
+import com.c4.hero.domain.promotion.dto.response.PromotionPlanResponseDTO;
+import com.c4.hero.domain.promotion.mapper.PromotionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * <pre>
+ * Class Name: PromotionQueryService
+ * Description: 승진 관련 조회 비즈니스 로직을 처리하는 서비스
+ *
+ * History
+ * 2025/12/19 (승건) 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PromotionQueryService {
+
+    private final PromotionMapper promotionMapper;
+    private final EmployeeDepartmentRepository departmentRepository;
+    private final EmployeeGradeRepository gradeRepository;
+
+    /**
+     * 승진 계획 목록을 페이징하여 조회합니다.
+     *
+     * @param isFinished 조회할 계획의 완료 여부 (true: 완료, false: 진행중, null: 전체)
+     * @param pageable   페이징 정보 (page, size, sort)
+     * @return 페이징된 승진 계획 목록
+     */
+    public PageResponse<PromotionPlanResponseDTO> getPromotionPlan(Boolean isFinished, Pageable pageable) {
+        // 1. 조건에 맞는 전체 데이터 개수 조회
+        long totalElements = promotionMapper.countPromotionPlan(isFinished);
+
+        // 2. 데이터가 없으면 빈 페이지 응답 반환
+        if (totalElements == 0) {
+            return PageResponse.of(Collections.emptyList(), pageable.getPageNumber(), pageable.getPageSize(), 0);
+        }
+
+        // 3. 페이징된 데이터 목록 조회
+        List<PromotionPlanResponseDTO> content = promotionMapper.selectPromotionPlan(
+                isFinished,
+                (int) pageable.getOffset(),
+                pageable.getPageSize()
+        );
+
+        // 4. PageResponse 객체를 생성하여 반환
+        return PageResponse.of(content, pageable.getPageNumber(), pageable.getPageSize(), totalElements);
+    }
+
+    /**
+     * 승진 계획의 상세 정보를 조회합니다.
+     *
+     * @param promotionId 조회할 승진 계획의 ID
+     * @return 승진 계획 상세 정보
+     * @throws BusinessException 승진 계획을 찾지 못했을 경우
+     */
+    public PromotionPlanDetailResponseDTO getPromotionPlanDetail(int promotionId) {
+        // 1. Mapper를 통해 상세 정보 조회
+        PromotionPlanDetailResponseDTO response = promotionMapper.selectPromotionPlanDetail(promotionId);
+
+        // 2. 조회 결과가 없으면 예외 발생
+        if (response == null) {
+            throw new BusinessException(ErrorCode.PROMOTION_PLAN_NOT_FOUND);
+        }
+
+        return response;
+    }
+
+    /**
+     * 승진 계획 등록 시 선택 가능한 옵션(부서 트리, 직급 목록)을 조회합니다.
+     *
+     * @return 승진 계획 옵션 정보
+     */
+    public PromotionOptionsDTO getPromotionOptions() {
+        // 1. 부서 트리 조회
+        List<PromotionDepartmentDTO> departmentTree = getDepartmentTree();
+
+        // 2. 직급 목록 조회
+        List<PromotionGradeDTO> gradeList = getGradeList();
+
+        return PromotionOptionsDTO.builder()
+                .promotionDepartmentDTOList(departmentTree)
+                .promotionGradeDTOList(gradeList)
+                .build();
+    }
+
+    /**
+     * 모든 부서를 조회하여 트리 구조로 변환합니다.
+     * (발령 대기, 관리자 부서는 제외)
+     */
+    private List<PromotionDepartmentDTO> getDepartmentTree() {
+        // 1. 모든 부서 조회 후, 불필요한 부서(-1, 0) 필터링
+        List<EmployeeDepartment> allDepartments = departmentRepository.findAll(Sort.by("departmentId"))
+                .stream()
+                .filter(dept -> dept.getDepartmentId() > 0)
+                .collect(Collectors.toList());
+
+        // 2. DTO 변환 및 Map에 저장 (ID -> DTO)
+        Map<Integer, PromotionDepartmentDTO> dtoMap = new HashMap<>();
+        for (EmployeeDepartment dept : allDepartments) {
+            dtoMap.put(dept.getDepartmentId(), PromotionDepartmentDTO.builder()
+                    .departmentId(dept.getDepartmentId())
+                    .departmentName(dept.getDepartmentName())
+                    .build());
+        }
+
+        List<PromotionDepartmentDTO> roots = new ArrayList<>();
+
+        // 3. 트리 구조 조립
+        for (EmployeeDepartment dept : allDepartments) {
+            PromotionDepartmentDTO currentDTO = dtoMap.get(dept.getDepartmentId());
+            Integer parentId = dept.getParentDepartmentId();
+
+            if (parentId == null) {
+                // 최상위 부서
+                roots.add(currentDTO);
+            } else {
+                // 하위 부서 -> 부모의 children에 추가
+                PromotionDepartmentDTO parentDTO = dtoMap.get(parentId);
+                if (parentDTO != null) {
+                    parentDTO.addChild(currentDTO);
+                }
+            }
+        }
+
+        return roots;
+    }
+
+    /**
+     * 모든 직급을 조회하여 DTO 리스트로 변환합니다.
+     * (관리자, 최하위 직급 제외)
+     */
+    private List<PromotionGradeDTO> getGradeList() {
+        return gradeRepository.findAll(Sort.by("gradeId")).stream()
+                .skip(2) // ID가 가장 작은 2개(관리자, 사원) 제외
+                .map(grade -> PromotionGradeDTO.builder()
+                        .gradeId(grade.getGradeId())
+                        .grade(grade.getGrade())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/hero-be/src/main/java/com/c4/hero/domain/settings/controller/SettingsController.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/settings/controller/SettingsController.java
@@ -1,6 +1,6 @@
 package com.c4.hero.domain.settings.controller;
 
-import com.c4.hero.common.response.ApiResponse;
+import com.c4.hero.common.response.CustomResponse;
 import com.c4.hero.common.response.PageResponse;
 import com.c4.hero.domain.employee.entity.Grade;
 import com.c4.hero.domain.employee.entity.JobTitle;
@@ -55,11 +55,11 @@ public class SettingsController {
 	 * @return 부서 트리 구조 목록
 	 */
 	@GetMapping("/departments")
-	public ResponseEntity<ApiResponse<List<SettingsDepartmentResponseDTO>>> getDepartments() {
+	public ResponseEntity<CustomResponse<List<SettingsDepartmentResponseDTO>>> getDepartments() {
 		List<SettingsDepartmentResponseDTO> departmentTree = settingsQueryService.getDepartmentTree();
 
 		log.info("department: {}", departmentTree);
-		return ResponseEntity.ok(ApiResponse.success(departmentTree));
+		return ResponseEntity.ok(CustomResponse.success(departmentTree));
 	}
 
 	/**
@@ -69,9 +69,9 @@ public class SettingsController {
 	 * @return 성공 메시지
 	 */
 	@PostMapping("/departments/tree")
-	public ResponseEntity<ApiResponse<String>> saveOrUpdateDepartments(@RequestBody List<SettingsDepartmentRequestDTO> departments) {
+	public ResponseEntity<CustomResponse<String>> saveOrUpdateDepartments(@RequestBody List<SettingsDepartmentRequestDTO> departments) {
 		settingsCommandService.updateDepartments(departments);
-		return ResponseEntity.ok(ApiResponse.success("Departments updated successfully"));
+		return ResponseEntity.ok(CustomResponse.success("Departments updated successfully"));
 	}
 
 	/**
@@ -80,11 +80,11 @@ public class SettingsController {
 	 * @return 전체 직급 목록
 	 */
 	@GetMapping("/grades")
-	public ResponseEntity<ApiResponse<List<Grade>>> getGrades() {
+	public ResponseEntity<CustomResponse<List<Grade>>> getGrades() {
 		List<Grade> grades = settingsQueryService.getAllGrades();
 
 		log.info("grades: {}", grades);
-		return ResponseEntity.ok(ApiResponse.success(grades));
+		return ResponseEntity.ok(CustomResponse.success(grades));
 	}
 
 	/**
@@ -94,9 +94,9 @@ public class SettingsController {
 	 * @return 성공 메시지
 	 */
 	@PostMapping("/grades/batch")
-	public ResponseEntity<ApiResponse<String>> updateGrades(@RequestBody List<SettingsGradeRequestDTO> grades) {
+	public ResponseEntity<CustomResponse<String>> updateGrades(@RequestBody List<SettingsGradeRequestDTO> grades) {
 		settingsCommandService.updateGrades(grades);
-		return ResponseEntity.ok(ApiResponse.success("Grades updated successfully"));
+		return ResponseEntity.ok(CustomResponse.success("Grades updated successfully"));
 	}
 
 	/**
@@ -105,11 +105,11 @@ public class SettingsController {
 	 * @return 전체 직책 목록
 	 */
 	@GetMapping("/job-titles")
-	public ResponseEntity<ApiResponse<List<JobTitle>>> getJobTitles() {
+	public ResponseEntity<CustomResponse<List<JobTitle>>> getJobTitles() {
 		List<JobTitle> jobTitles = settingsQueryService.getAllJobTitles();
 
 		log.info("jobTitles: {}", jobTitles);
-		return ResponseEntity.ok(ApiResponse.success(jobTitles));
+		return ResponseEntity.ok(CustomResponse.success(jobTitles));
 	}
 
 	/**
@@ -119,9 +119,9 @@ public class SettingsController {
 	 * @return 성공 메시지
 	 */
 	@PostMapping("/job-titles/batch")
-	public ResponseEntity<ApiResponse<String>> updateJobTitles(@RequestBody List<SettingsJobTitleRequestDTO> jobTitles) {
+	public ResponseEntity<CustomResponse<String>> updateJobTitles(@RequestBody List<SettingsJobTitleRequestDTO> jobTitles) {
 		settingsCommandService.updateJobTitles(jobTitles);
-		return ResponseEntity.ok(ApiResponse.success("Job titles updated successfully"));
+		return ResponseEntity.ok(CustomResponse.success("Job titles updated successfully"));
 	}
 
 	/**
@@ -130,9 +130,9 @@ public class SettingsController {
 	 * @return 로그인 정책 값
 	 */
 	@GetMapping("/login-policy")
-	public ResponseEntity<ApiResponse<Integer>> getLoginPolicy() {
+	public ResponseEntity<CustomResponse<Integer>> getLoginPolicy() {
 		Integer loginPolicy = settingsQueryService.getLoginPolicy();
-		return ResponseEntity.ok(ApiResponse.success(loginPolicy));
+		return ResponseEntity.ok(CustomResponse.success(loginPolicy));
 	}
 
 	/**
@@ -142,9 +142,9 @@ public class SettingsController {
 	 * @return 성공 메시지
 	 */
 	@PutMapping("/login-policy")
-	public ResponseEntity<ApiResponse<String>> setLoginPolicy(@RequestBody SettingsLoginPolicyRequestDTO policy) {
+	public ResponseEntity<CustomResponse<String>> setLoginPolicy(@RequestBody SettingsLoginPolicyRequestDTO policy) {
 		settingsCommandService.setLoginPolicy(policy);
-		return ResponseEntity.ok(ApiResponse.success("Login policy updated successfully"));
+		return ResponseEntity.ok(CustomResponse.success("Login policy updated successfully"));
 	}
 
 	/**
@@ -155,11 +155,11 @@ public class SettingsController {
 	 * @return 각 사원들이 들고 있는 권한 정보 List
 	 */
 	@GetMapping("/permissions")
-	public ResponseEntity<ApiResponse<PageResponse<SettingsPermissionsResponseDTO>>> getPermissions(
+	public ResponseEntity<CustomResponse<PageResponse<SettingsPermissionsResponseDTO>>> getPermissions(
 			Pageable pageable,
 			@RequestParam(required = false) String query) {
 		PageResponse<SettingsPermissionsResponseDTO> permissions = settingsQueryService.getEmployeePermissions(pageable, query);
-		return ResponseEntity.ok(ApiResponse.success(permissions));
+		return ResponseEntity.ok(CustomResponse.success(permissions));
 	}
 
 	/**
@@ -168,9 +168,9 @@ public class SettingsController {
 	 * @return 전체 권한 목록
 	 */
 	@GetMapping("/roles")
-	public ResponseEntity<ApiResponse<List<Role>>> getRoles() {
+	public ResponseEntity<CustomResponse<List<Role>>> getRoles() {
 		List<Role> roles = settingsQueryService.getAllRoles();
-		return ResponseEntity.ok(ApiResponse.success(roles));
+		return ResponseEntity.ok(CustomResponse.success(roles));
 	}
 
 	/**
@@ -180,8 +180,8 @@ public class SettingsController {
 	 * @return 성공 메시지
 	 */
 	@PutMapping("/permissions")
-	public ResponseEntity<ApiResponse<String>> updatePermissions(@RequestBody SettingsPermissionsRequestDTO dto) {
+	public ResponseEntity<CustomResponse<String>> updatePermissions(@RequestBody SettingsPermissionsRequestDTO dto) {
 		settingsCommandService.updatePermissions(dto);
-		return ResponseEntity.ok(ApiResponse.success("Permissions updated successfully"));
+		return ResponseEntity.ok(CustomResponse.success("Permissions updated successfully"));
 	}
 }

--- a/hero-be/src/main/resources/mapper/promotion/PromotionMapper.xml
+++ b/hero-be/src/main/resources/mapper/promotion/PromotionMapper.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.c4.hero.domain.promotion.mapper.PromotionMapper">
+
+    <!-- ================================================= -->
+    <!-- ResultMaps                                        -->
+    <!-- ================================================= -->
+
+    <!-- 승진 계획 목록 조회를 위한 ResultMap -->
+    <resultMap id="promotionPlanResultMap" type="com.c4.hero.domain.promotion.dto.response.PromotionPlanResponseDTO">
+        <id property="promotionId" column="promotion_id"/>
+        <result property="planName" column="plan_name"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="nominationDeadlineAt" column="nomination_deadline_at"/>
+        <result property="appointmentAt" column="appointment_at"/>
+    </resultMap>
+
+    <!-- 승진 계획 상세 조회를 위한 ResultMap (하위 상세 계획 포함) -->
+    <resultMap id="promotionDetailPlanResultMap"
+               type="com.c4.hero.domain.promotion.dto.response.PromotionPlanDetailResponseDTO">
+        <id property="promotionId" column="promotion_id"/>
+        <result property="planName" column="plan_name"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="nominationDeadlineAt" column="nomination_deadline_at"/>
+        <result property="appointmentAt" column="appointment_at"/>
+        <result property="planContent" column="plan_content"/>
+        <collection property="detailPlan"
+                    javaType="java.util.List"
+                    ofType="com.c4.hero.domain.promotion.dto.PromotionDetailPlanDTO"
+                    select="findDetailPlanByPromotionId"
+                    column="promotion_id"/>
+    </resultMap>
+
+    <!-- 승진 상세 계획과 하위 후보자 목록을 위한 ResultMap -->
+    <resultMap id="detailPlanWithCandidatesMap" type="com.c4.hero.domain.promotion.dto.PromotionDetailPlanDTO">
+        <result property="departmentId" column="department_id"/>
+        <result property="department" column="department_name"/>
+        <result property="gradeId" column="grade_id"/>
+        <result property="grade" column="grade_name"/>
+        <result property="quotaCount" column="quota_count"/>
+        <collection property="candidateList"
+                    javaType="java.util.List"
+                    ofType="com.c4.hero.domain.promotion.dto.PromotionCandidateDTO"
+                    select="findCandidatesByDetailPlan"
+                    column="{promotionDetailId=promotion_detail_id}"/>
+    </resultMap>
+
+
+    <!-- ================================================= -->
+    <!-- SELECT Queries                                    -->
+    <!-- ================================================= -->
+
+    <!-- 승진 계획 목록 조회 (페이징) -->
+    <select id="selectPromotionPlan" resultMap="promotionPlanResultMap">
+        SELECT
+            promotion_plan_id AS promotion_id,
+            plan_name,
+            created_at,
+            nomination_deadline_at,
+            appointment_at
+        FROM
+            tbl_promotion_plan
+        <where>
+            <if test="isFinished != null and isFinished == true">
+                AND appointment_at &lt;= NOW()
+            </if>
+            <if test="isFinished != null and isFinished == false">
+                AND appointment_at &gt; NOW()
+            </if>
+        </where>
+        ORDER BY
+            created_at DESC
+        LIMIT
+            #{limit} OFFSET #{offset}
+    </select>
+
+    <!-- 승진 계획 전체 개수 조회 -->
+    <select id="countPromotionPlan" resultType="long">
+        SELECT
+            count(*)
+        FROM
+            tbl_promotion_plan
+        <where>
+            <if test="isFinished != null and isFinished == true">
+                AND appointment_at &lt;= NOW()
+            </if>
+            <if test="isFinished != null and isFinished == false">
+                AND appointment_at &gt; NOW()
+            </if>
+        </where>
+    </select>
+
+    <!-- 승진 계획 상세 정보 조회 -->
+    <select id="selectPromotionPlanDetail" resultMap="promotionDetailPlanResultMap">
+        SELECT
+            promotion_plan_id AS promotion_id,
+            plan_name,
+            created_at,
+            nomination_deadline_at,
+            appointment_at,
+            plan_content
+        FROM
+            tbl_promotion_plan
+        WHERE
+            promotion_plan_id = #{promotionId}
+    </select>
+
+    <!-- 특정 승진 계획에 속한 상세 계획 목록 조회 -->
+    <select id="findDetailPlanByPromotionId" resultMap="detailPlanWithCandidatesMap">
+        SELECT
+            pd.promotion_detail_id,
+            pd.promotion_plan_id,
+            d.department_id,
+            d.department_name,
+            g.grade_id,
+            g.grade AS grade_name,
+            pd.quota_count
+        FROM
+            tbl_promotion_detail pd
+        JOIN
+            tbl_department d ON pd.department_id = d.department_id
+        JOIN
+            tbl_grade g ON pd.grade_id = g.grade_id
+        WHERE
+            pd.promotion_plan_id = #{promotionId}
+    </select>
+
+    <!-- 특정 상세 계획에 속한 후보자 목록 조회 -->
+    <select id="findCandidatesByDetailPlan" resultType="com.c4.hero.domain.promotion.dto.PromotionCandidateDTO">
+        SELECT
+            c.employee_id,
+            e.employee_name,
+            e.employee_number,
+            d.department_name AS department,
+            g.grade AS grade,
+            n.employee_name AS nominatorName,
+            c.nomination_reason,
+            c.is_approved,
+            c.rejection_reason,
+            c.evaluation_point
+        FROM
+            tbl_promotion_candidate c
+        JOIN
+            tbl_employee e ON c.employee_id = e.employee_id
+        JOIN
+            tbl_department d ON e.department_id = d.department_id
+        JOIN
+            tbl_grade g ON e.grade_id = g.grade_id
+        LEFT JOIN
+            tbl_employee n ON c.nominator_id = n.employee_id
+        WHERE
+            c.promotion_detail_id = #{promotionDetailId}
+    </select>
+
+</mapper>


### PR DESCRIPTION
<!--
[Feat] 승진 계획 관리 기능 구현 및 후보자 자동 선정 로직 추가
-->

## 📋 작업 내용
- 승진 계획 등록, 목록 조회, 상세 조회 API 구현
- 승진 계획 등록 시 조건에 맞는 후보자 자동 탐색 및 저장 로직 구현
- 승진 계획 등록에 필요한 옵션(부서 트리, 직급 목록) 조회 API 구현
- 승진 관련 엔티티, DTO, Repository, Mapper 구현 및 코드 컨벤션 적용

## 🔧 작업 상세

### 변경된 파일
- `src/main/java/com/c4/hero/domain/promotion/controller/PromotionController.java`
- `src/main/java/com/c4/hero/domain/promotion/service/PromotionCommandService.java`
- `src/main/java/com/c4/hero/domain/promotion/service/PromotionQueryService.java`
- `src/main/java/com/c4/hero/domain/promotion/entity/*.java` (PromotionPlan, PromotionDetail, PromotionCandidate)
- `src/main/java/com/c4/hero/domain/promotion/dto/**/*.java`
- `src/main/java/com/c4/hero/domain/employee/repository/EmployeeRepository.java`
- `src/main/resources/mapper/promotion/PromotionMapper.xml`

### 주요 로직 설명
- **승진 계획 등록 (`registerPromotionPlan`)**:
    - 요청받은 승진 계획 정보를 저장하고, 각 상세 계획(`PromotionDetail`)에 대해 `autoRegisterCandidates` 메소드를 호출합니다.
    - `autoRegisterCandidates`는 해당 부서(하위 부서 포함)와 직급 조건(바로 아래 직급)을 만족하고, 필요 포인트 이상을 보유한 직원을 자동으로 찾아 후보자로 등록합니다.
    - 관리자(0)나 최하위 직급(사원)을 대상으로 하는 승진 계획은 예외 처리하여 방지했습니다.
- **승진 계획 조회**:
    - MyBatis를 사용하여 승진 계획 목록(페이징)과 상세 정보를 조회합니다.
    - 상세 조회 시 `Nested Select`를 사용하여 하위 상세 계획과 후보자 목록까지 한 번에 조회하도록 구현했습니다.
- **옵션 조회 (`getPromotionOptions`)**:
    - 승진 계획 등록 시 필요한 부서 목록을 트리 구조로 변환하여 제공합니다.
    - 직급 목록은 관리자와 최하위 직급을 제외하고 제공하여 유효한 선택지만 노출합니다.

## ✅ 테스트 체크리스트
- [x] 로컬 환경에서 정상 동작 확인
- [x] 주요 기능 시나리오 테스트 완료 (승진 계획 등록, 후보자 자동 선정, 조회)
- [x] Postman을 이용한 API 테스트 완료

## 🖼️ 스크린샷 (UI 변경 시)

### PostMan Json
<img width="475" height="315" alt="image" src="https://github.com/user-attachments/assets/1b487e37-8e65-4bc9-9305-55b047271505" />

### 계획
<img width="1807" height="36" alt="image" src="https://github.com/user-attachments/assets/20829c3e-a1a9-4d2e-a9fe-45b71e04593a" /> 

### 상세 계획
<img width="1752" height="38" alt="image" src="https://github.com/user-attachments/assets/5e470730-2400-42f3-ae34-a7701fd33b7f" />

### 등록된 후보자
<img width="1912" height="70" alt="image" src="https://github.com/user-attachments/assets/e3ad29f9-cb18-4ef9-9602-82b0b4c6a76a" />


## 🤔 리뷰 포인트
<!--
리뷰어가 특별히 집중해서 봐줬으면 하는 부분을 적어주세요.
-->
- `PromotionCommandService`의 `autoRegisterCandidates` 메소드에서 후보자를 선정하는 로직이 비즈니스 요구사항에 부합하는지 확인 부탁드립니다. (특히 직급 비교 및 포인트 체크 부분)
- `PromotionMapper.xml`의 `resultMap` 설정과 `Nested Select` 쿼리가 효율적으로 작성되었는지 검토 부탁드립니다.

## 🔗 관련 이슈

- Closes #57

## 💬 추가 코멘트

- 승진 후보자 선정 시, 현재는 '직전 직급'과 '필요 포인트'만 기준으로 하고 있습니다. 추후 근속 연수 등 추가 조건이 필요하면 로직 확장이 필요할 수 있습니다.