### PR TITLE
[Fix] 페이징 처리 LIMIT 절 추가 및 결재선 로직 수정

### DIFF
--- a/hero-be/src/main/java/com/c4/hero/domain/approval/controller/ApprovalQueryController.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/approval/controller/ApprovalQueryController.java
@@ -1,11 +1,7 @@
 package com.c4.hero.domain.approval.controller;
 
 import com.c4.hero.common.response.PageResponse;
-import com.c4.hero.domain.approval.dto.*;
-import com.c4.hero.domain.approval.dto.response.VacationTypeResponseDTO;
-import com.c4.hero.domain.approval.dto.response.ApprovalDocumentDetailResponseDTO;
-import com.c4.hero.domain.approval.dto.response.ApprovalDocumentsResponseDTO;
-import com.c4.hero.domain.approval.dto.response.ApprovalTemplateDetailResponseDTO;
+import com.c4.hero.domain.approval.dto.response.*;
 import com.c4.hero.domain.approval.dto.organization.*;
 import com.c4.hero.domain.approval.entity.ApprovalResignType;
 import com.c4.hero.domain.approval.repository.ApprovalEmployeeRepository;

--- a/hero-be/src/main/java/com/c4/hero/domain/approval/dto/response/ApprovalTemplateResponseDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/approval/dto/response/ApprovalTemplateResponseDTO.java
@@ -1,4 +1,4 @@
-package com.c4.hero.domain.approval.dto;
+package com.c4.hero.domain.approval.dto.response;
 
 import lombok.*;
 

--- a/hero-be/src/main/java/com/c4/hero/domain/approval/dto/response/BeforePayrollResponseDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/approval/dto/response/BeforePayrollResponseDTO.java
@@ -1,4 +1,4 @@
-package com.c4.hero.domain.approval.dto;
+package com.c4.hero.domain.approval.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/hero-be/src/main/java/com/c4/hero/domain/approval/dto/response/PersonnelTypesResponseDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/approval/dto/response/PersonnelTypesResponseDTO.java
@@ -1,4 +1,4 @@
-package com.c4.hero.domain.approval.dto;
+package com.c4.hero.domain.approval.dto.response;
 
 import com.c4.hero.domain.employee.entity.EmployeeDepartment;
 import com.c4.hero.domain.employee.entity.Grade;

--- a/hero-be/src/main/java/com/c4/hero/domain/approval/dto/response/ResignTypeResponseDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/approval/dto/response/ResignTypeResponseDTO.java
@@ -1,4 +1,4 @@
-package com.c4.hero.domain.approval.dto;
+package com.c4.hero.domain.approval.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/hero-be/src/main/java/com/c4/hero/domain/approval/dto/response/WorkSystemTypeResponseDTO.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/approval/dto/response/WorkSystemTypeResponseDTO.java
@@ -1,4 +1,4 @@
-package com.c4.hero.domain.approval.dto;
+package com.c4.hero.domain.approval.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/hero-be/src/main/java/com/c4/hero/domain/approval/service/ApprovalQueryService.java
+++ b/hero-be/src/main/java/com/c4/hero/domain/approval/service/ApprovalQueryService.java
@@ -4,7 +4,7 @@ import com.c4.hero.common.response.PageResponse;
 import com.c4.hero.common.s3.S3Service;
 import com.c4.hero.domain.approval.dto.ApprovalDefaultLineDTO;
 import com.c4.hero.domain.approval.dto.ApprovalDefaultRefDTO;
-import com.c4.hero.domain.approval.dto.ApprovalTemplateResponseDTO;
+import com.c4.hero.domain.approval.dto.response.ApprovalTemplateResponseDTO;
 import com.c4.hero.domain.approval.dto.response.*;
 import com.c4.hero.domain.approval.entity.*;
 import com.c4.hero.domain.approval.mapper.ApprovalMapper;

--- a/hero-be/src/main/resources/mapper/approval/ApprovalMapper.xml
+++ b/hero-be/src/main/resources/mapper/approval/ApprovalMapper.xml
@@ -255,6 +255,9 @@
 
         <!-- 기본 정렬: 최신순 (상신일시 내림차순) -->
         ORDER BY D.draft_date DESC
+
+        <!-- 페이징 처리 -->
+        LIMIT #{size} OFFSET #{offset}
     </select>
 
     <!-- 문서함 전체 개수 조회 (페이징용) -->


### PR DESCRIPTION

## 📋 작업 내용
- 한 페이지에 대한 데이터를 위해 sql문에 LIMIT절 추가
- 결재선이 1단계인 경우를 위한 문서 상신-승인 로직 추가
- ResponseDTO파일 패키지 이동

## 🔧 작업 상세


### 변경된 파일
- `ApprovalCommandService.java` - 상신문서 중 결재선이 1단계(기안자)만 존재하는 경우 상신 후 즉시 승인 처리 로직 추가
- `ApprovalMapper.xml` - 페이징 처리 중 LIMIT 절 누락으로 인한 모든 데이터 조회 -> 페이징별 데이터 조회

### 주요 로직 설명
- 기안자만 결재선에 올라있을 경우 상신 즉시 승인 처리.
```
if ("INPROGRESS".equals(status)) {
            List<ApprovalLine> lines = lineRepository.findByDocIdOrderBySeqAsc(savedDoc.getDocId());
            boolean onlyDrafter = lines.stream()
                    .allMatch(line -> line.getSeq() == 1);

            if (onlyDrafter) {
                // 결재선이 기안자(seq=1)만 있는 경우 자동 승인
                savedDoc.complete();
                String docNo = generateDocNo();
                savedDoc.assignDocNo(docNo);
                documentRepository.save(savedDoc);

                log.info("결재선이 1단계만 존재 - 자동 승인 처리 완료, 문서번호: {}", docNo);

                // 승인 완료 이벤트 발행
                publishApprovalCompletedEvent(savedDoc);
            }
        }
```

## ✅ 테스트 체크리스트
- [x] 로컬 환경에서 정상 동작 확인
- [x] 주요 기능 시나리오 테스트 완료
- [x] 브라우저 콘솔 에러 없음
- [ ] 반응형 디자인 확인 (모바일/태블릿/데스크탑)
- [ ] 크로스 브라우저 테스트 (Chrome, Safari, Firefox)


## 🤔 리뷰 포인트
- 코딩 컨벤션 위주로 검토해주세요

## 🔗 관련 이슈
- Closes #137 


